### PR TITLE
Pin pysomneo<4

### DIFF
--- a/custom_components/smartsleep/manifest.json
+++ b/custom_components/smartsleep/manifest.json
@@ -11,6 +11,6 @@
   "loggers": [
     "smartsleep" 
   ],
-  "requirements": ["pysomneo>=2.5.2"],
+  "requirements": ["pysomneo>=2.5.2,<4"],
   "version": "4.0.0.1"
 }


### PR DESCRIPTION
Pysomneo underwent a rewrite in v4.0.0 that includes breaking changes.

#### pysomneo changes:
https://github.com/theneweinstein/pysomneo/commit/e33c8932c4f6474381e326ad85a06cb195711c76

#### HA logs
```
2024-01-05 21:12:38.071 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry SmartSleep for smartsleep
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 402, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/smartsleep/__init__.py", line 35, in async_setup_entry
    coordinator = SmartSleepCoordinator(
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/smartsleep/__init__.py", line 99, in __init__
    self.somneo = Somneo(host, use_session=use_session)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```